### PR TITLE
PHP 8 - Error handling has changed

### DIFF
--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -1504,7 +1504,7 @@ class Smarty extends Smarty_Internal_TemplateBase
      *
      * @return boolean
      */
-    public static function mutingErrorHandler($errno, $errstr, $errfile, $errline, $errcontext)
+    public static function mutingErrorHandler($errno, $errstr, $errfile, $errline, $errcontext = [])
     {
         $_is_muted_directory = false;
 


### PR DESCRIPTION
The `$errcontext` parameter has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0. If  the function defines this parameter without a default, an error of "too few arguments" will be raised when it is called.